### PR TITLE
Allow multiple set-cookie headers.

### DIFF
--- a/lib/plug_cowboy2/conn.ex
+++ b/lib/plug_cowboy2/conn.ex
@@ -113,16 +113,14 @@ defmodule Plug.Adapters.Cowboy2.Conn do
   end
 
   defp to_headers_map(headers) when is_list(headers) do
-    headers
-    |> :maps.from_list()
-    |> to_headers_map()
-  end
-
-  defp to_headers_map(headers) when is_map(headers) do
-    case Map.get(headers, "set-cookie") do
-      set_cookie when is_binary(set_cookie) -> Map.put(headers, "set-cookie", [set_cookie])
-      _                                     -> headers
-    end
+    # Group set-cookie headers into a list for a single `set-cookie` key since cowboy 2 requires headers as a map.
+    Enum.reduce(headers, %{}, fn
+      ({key = "set-cookie", value}, acc) ->
+        set_cookies = Map.get(acc, key, [])
+        Map.put(acc, key, [value | set_cookies])
+      ({key, value}, acc) ->
+        Map.put(acc, key, value)
+    end)
   end
 
   ## Multipart


### PR DESCRIPTION
Currently, code like this
`Plug.Conn.put_resp_cookie(conn, "a", "b") |> Plug.Conn.put_resp_cookie("x", "y")`
will result in only one of the cookies being sent to the client and the other one is ignored.

With this change, multiple set-cookie headers can be sent (thus the above code will work as intended), as allowed by https://github.com/ninenines/cowboy/blob/3b91523a3c84a882dcc83f0591b919a939cb72c2/src/cowboy_http.erl#L903.

