### PR TITLE
Fix for argument error in multipart uploads

### DIFF
--- a/lib/plug_cowboy2/conn.ex
+++ b/lib/plug_cowboy2/conn.ex
@@ -126,7 +126,7 @@ defmodule Plug.Adapters.Cowboy2.Conn do
   ## Multipart
 
   defp parse_multipart({:ok, headers, req}, limit, opts, headers_opts, acc, callback) when limit >= 0 do
-    case callback.(headers) do
+    case callback.(to_headers_list(headers)) do
       {:binary, name} ->
         {:ok, limit, body, req} =
           parse_multipart_body(:cowboy_req.read_part_body(req, opts), limit, opts, "")


### PR DESCRIPTION
I think this change is required to handle multipart headers. They need to be converted to a list.